### PR TITLE
Generate enum property if values key is passed in documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 #### Fixes
 
-* Your contribution here.
+* [#8](https://github.com/ruby-grape/grape-swagger-entity/pull/8) Generate enum property if values key is passed in documentation - [@lordnibbler](https://github.com/lordnibbler)
 
 ### 0.1.4 (June 7, 2016)
 

--- a/lib/grape-swagger/entity/parser.rb
+++ b/lib/grape-swagger/entity/parser.rb
@@ -62,8 +62,9 @@ module GrapeSwagger
               }
             end
 
-            if entity_options[:values] && entity_options[:values].is_a?(Array)
-              memo[entity_name][:enum] = entity_options[:values]
+            if entity_options[:documentation] && entity_options[:documentation][:values]
+              values = entity_options[:documentation][:values]
+              memo[entity_name][:enum] = values if values.is_a?(Array)
             end
 
             if entity_options[:documentation] && entity_options[:documentation][:is_array]

--- a/spec/grape-swagger/entities/response_model_spec.rb
+++ b/spec/grape-swagger/entities/response_model_spec.rb
@@ -138,12 +138,12 @@ describe 'responseModel' do
   end
 end
 
-describe 'should build definition from given entity' do
+describe 'building definitions from given entities' do
   before :all do
     module TheseApi
       module Entities
         class Kind < Grape::Entity
-          expose :id, documentation: { type: Integer, desc: 'Title of the kind.' }
+          expose :id, documentation: { type: Integer, desc: 'Title of the kind.', values: [1, 2] }
         end
 
         class Relation < Grape::Entity
@@ -187,12 +187,12 @@ describe 'should build definition from given entity' do
     JSON.parse(last_response.body)
   end
 
-  it 'it prefer entity over others' do
+  it 'prefers entity over other `using` values' do
     expect(subject['definitions']).to eql(
       'Kind' => {
         'type' => 'object',
         'properties' => {
-          'id' => { 'type' => 'integer', 'format' => 'int32', 'description' => 'Title of the kind.' }
+          'id' => { 'type' => 'integer', 'format' => 'int32', 'description' => 'Title of the kind.', 'enum' => [1, 2] }
         }
       },
       'Tag' => { 'type' => 'object', 'properties' => { 'name' => { 'type' => 'string', 'description' => 'Name' } } },


### PR DESCRIPTION
`grape-entity` raises an error if `values:` key is passed outside of the `documentation` hash:

```ruby
expose :thing2,  values: [1, 2, 3], documentation: { type: Integer }
# => gems/grape-entity-0.5.1/lib/grape_entity/entity.rb:539:in `block in valid_options': :values is not a valid option. (ArgumentError)
```

However, `grape-swagger-entity` has business logic requiring the `values:` key to be passed like the above example.

This PR changes the business logic to expect the `values:` key inside the `documentation:` hash as such:

```ruby
expose :thing2, documentation: { type: Integer, values: [1, 2, 3] }
```