### PR TITLE
Allow parsing Entity with no endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 #### Features
 
 * [#11](https://github.com/ruby-grape/grape-swagger-entity/pull/11): Use an automated PR linter, [danger.systems](http://danger.systems) - [@Bugagazavr](https://github.com/Bugagazavr).
+* [#12](https://github.com/ruby-grape/grape-swagger-entity/pull/12): Allow parsing Entity with no endpoint - [@lordnibbler](https://github.com/lordnibbler).
 * Your contribution here.
 
 #### Fixes

--- a/lib/grape-swagger/entity/parser.rb
+++ b/lib/grape-swagger/entity/parser.rb
@@ -38,7 +38,7 @@ module GrapeSwagger
           end
 
           if model
-            name = endpoint.send(:expose_params_from_model, model)
+            name = endpoint.nil? ? model.to_s.demodulize : endpoint.send(:expose_params_from_model, model)
             memo[entity_name] = entity_model_type(name, entity_options)
           else
             documented_type = entity_options[:type]

--- a/spec/grape-swagger/entities/response_model_spec.rb
+++ b/spec/grape-swagger/entities/response_model_spec.rb
@@ -1,69 +1,8 @@
 require 'spec_helper'
+require_relative '../../../spec/support/shared_contexts/this_api'
 
 describe 'responseModel' do
-  before :all do
-    module ThisApi
-      module Entities
-        class Kind < Grape::Entity
-          expose :title, documentation: { type: 'string', desc: 'Title of the kind.' }
-        end
-
-        class Relation < Grape::Entity
-          expose :name, documentation: { type: 'string', desc: 'Name' }
-        end
-        class Tag < Grape::Entity
-          expose :name, documentation: { type: 'string', desc: 'Name' }
-        end
-        class Error < Grape::Entity
-          expose :code, documentation: { type: 'string', desc: 'Error code' }
-          expose :message, documentation: { type: 'string', desc: 'Error message' }
-        end
-
-        class Something < Grape::Entity
-          expose :text, documentation: { type: 'string', desc: 'Content of something.' }
-          expose :colors, documentation: { type: 'string', desc: 'Colors', is_array: true }
-          expose :kind, using: Kind, documentation: { type: 'ThisApi::Kind', desc: 'The kind of this something.' }
-          expose :kind2, using: Kind, documentation: { desc: 'Secondary kind.' }
-          expose :kind3, using: ThisApi::Entities::Kind, documentation: { desc: 'Tertiary kind.' }
-          expose :tags, using: ThisApi::Entities::Tag, documentation: { desc: 'Tags.', is_array: true }
-          expose :relation, using: ThisApi::Entities::Relation, documentation: { type: 'ThisApi::Relation', desc: 'A related model.' }
-        end
-      end
-
-      class ResponseModelApi < Grape::API
-        format :json
-        desc 'This returns something',
-             is_array: true,
-             http_codes: [{ code: 200, message: 'OK', model: Entities::Something }]
-        get '/something' do
-          something = OpenStruct.new text: 'something'
-          present something, with: Entities::Something
-        end
-
-        # something like an index action
-        desc 'This returns something or an error',
-             entity: Entities::Something,
-             http_codes: [
-               { code: 200, message: 'OK', model: Entities::Something },
-               { code: 403, message: 'Refused to return something', model: Entities::Error }
-             ]
-        params do
-          optional :id, type: Integer
-        end
-        get '/something/:id' do
-          if params[:id] == 1
-            something = OpenStruct.new text: 'something'
-            present something, with: Entities::Something
-          else
-            error = OpenStruct.new code: 'some_error', message: 'Some error'
-            present error, with: Entities::Error
-          end
-        end
-
-        add_swagger_documentation
-      end
-    end
-  end
+  include_context 'this api'
 
   def app
     ThisApi::ResponseModelApi

--- a/spec/grape-swagger/entities/response_model_spec.rb
+++ b/spec/grape-swagger/entities/response_model_spec.rb
@@ -1,5 +1,4 @@
 require 'spec_helper'
-require_relative '../../../spec/support/shared_contexts/this_api'
 
 describe 'responseModel' do
   include_context 'this api'

--- a/spec/grape-swagger/entity/parser_spec.rb
+++ b/spec/grape-swagger/entity/parser_spec.rb
@@ -1,0 +1,20 @@
+require 'spec_helper'
+require_relative '../../../spec/support/shared_contexts/this_api'
+
+describe GrapeSwagger::Entity::Parser do
+  include_context 'this api'
+
+  describe '#call' do
+    subject(:parsed_entity) { described_class.new(ThisApi::Entities::Something, endpoint).call }
+
+    context 'when no endpoint is passed' do
+      let(:endpoint) { nil }
+
+      it 'parses the model with the correct :using definition' do
+        expect(parsed_entity[:kind]['$ref']).to eq('#/definitions/Kind')
+        expect(parsed_entity[:kind2]['$ref']).to eq('#/definitions/Kind')
+        expect(parsed_entity[:kind3]['$ref']).to eq('#/definitions/Kind')
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -18,3 +18,5 @@ RSpec.configure do |config|
   config.order = 'random'
   config.seed = 40_834
 end
+
+Dir['spec/support/**/*.rb'].each { |file| require "./#{file}" }

--- a/spec/support/shared_contexts/this_api.rb
+++ b/spec/support/shared_contexts/this_api.rb
@@ -1,0 +1,65 @@
+shared_context 'this api' do
+  before :all do
+    module ThisApi
+      module Entities
+        class Kind < Grape::Entity
+          expose :title, documentation: { type: 'string', desc: 'Title of the kind.' }
+        end
+
+        class Relation < Grape::Entity
+          expose :name, documentation: { type: 'string', desc: 'Name' }
+        end
+        class Tag < Grape::Entity
+          expose :name, documentation: { type: 'string', desc: 'Name' }
+        end
+        class Error < Grape::Entity
+          expose :code, documentation: { type: 'string', desc: 'Error code' }
+          expose :message, documentation: { type: 'string', desc: 'Error message' }
+        end
+
+        class Something < Grape::Entity
+          expose :text, documentation: { type: 'string', desc: 'Content of something.' }
+          expose :colors, documentation: { type: 'string', desc: 'Colors', is_array: true }
+          expose :kind, using: Kind, documentation: { type: 'ThisApi::Kind', desc: 'The kind of this something.' }
+          expose :kind2, using: Kind, documentation: { desc: 'Secondary kind.' }
+          expose :kind3, using: ThisApi::Entities::Kind, documentation: { desc: 'Tertiary kind.' }
+          expose :tags, using: ThisApi::Entities::Tag, documentation: { desc: 'Tags.', is_array: true }
+          expose :relation, using: ThisApi::Entities::Relation, documentation: { type: 'ThisApi::Relation', desc: 'A related model.' }
+        end
+      end
+
+      class ResponseModelApi < Grape::API
+        format :json
+        desc 'This returns something',
+             is_array: true,
+             http_codes: [{ code: 200, message: 'OK', model: Entities::Something }]
+        get '/something' do
+          something = OpenStruct.new text: 'something'
+          present something, with: Entities::Something
+        end
+
+        # something like an index action
+        desc 'This returns something or an error',
+             entity: Entities::Something,
+             http_codes: [
+               { code: 200, message: 'OK', model: Entities::Something },
+               { code: 403, message: 'Refused to return something', model: Entities::Error }
+             ]
+        params do
+          optional :id, type: Integer
+        end
+        get '/something/:id' do
+          if params[:id] == 1
+            something = OpenStruct.new text: 'something'
+            present something, with: Entities::Something
+          else
+            error = OpenStruct.new code: 'some_error', message: 'Some error'
+            present error, with: Entities::Error
+          end
+        end
+
+        add_swagger_documentation
+      end
+    end
+  end
+end


### PR DESCRIPTION
In some cases, we want to document entities or response definitions separate from an endpoint. This allows us to generate documentation while passing an endpoint as nil.