### PR TITLE
Entity name could be overridden by name specified in documentation.

### DIFF
--- a/lib/grape-swagger/entity/parser.rb
+++ b/lib/grape-swagger/entity/parser.rb
@@ -33,8 +33,9 @@ module GrapeSwagger
           entity_name = entity_options[:as] if entity_options[:as]
           model = entity_options[:using] if entity_options[:using].present?
 
-          if entity_options[:documentation] && could_it_be_a_model?(entity_options[:documentation])
-            model ||= entity_options[:documentation][:type]
+          if entity_options[:documentation]
+            entity_name = entity_options[:documentation][:name] if entity_options[:documentation][:name]
+            model ||= entity_options[:documentation][:type] if could_it_be_a_model?(entity_options[:documentation])
           end
 
           if model

--- a/spec/grape-swagger/entities/response_model_spec.rb
+++ b/spec/grape-swagger/entities/response_model_spec.rb
@@ -56,7 +56,9 @@ describe 'responseModel' do
             'kind2' => { '$ref' => '#/definitions/Kind', 'description' => 'Secondary kind.' },
             'kind3' => { '$ref' => '#/definitions/Kind', 'description' => 'Tertiary kind.' },
             'tags' => { 'type' => 'array', 'items' => { '$ref' => '#/definitions/Tag' }, 'description' => 'Tags.' },
-            'relation' => { '$ref' => '#/definitions/Relation', 'description' => 'A related model.' } }
+            'relation' => { '$ref' => '#/definitions/Relation', 'description' => 'A related model.' },
+            "goodname"=>{"type"=>"string", "description"=>"Doc name override."}
+           }
     )
 
     expect(subject['definitions'].keys).to include 'Kind'
@@ -73,6 +75,7 @@ describe 'responseModel' do
     expect(subject['definitions']['Tag']).to eq(
       'type' => 'object', 'properties' => { 'name' => { 'type' => 'string', 'description' => 'Name' } }
     )
+
   end
 end
 
@@ -98,6 +101,7 @@ describe 'building definitions from given entities' do
           expose :kind3, using: TheseApi::Entities::Kind, documentation: { desc: 'Tertiary kind.' }
           expose :tags, using: TheseApi::Entities::Tag, documentation: { desc: 'Tags.', is_array: true }
           expose :relation, using: TheseApi::Entities::Relation, documentation: { type: 'TheseApi::Relation', desc: 'A related model.' }
+          expose :override_name, documentation: { name: 'goodname', desc: 'Doc name override.' }
         end
       end
 
@@ -143,7 +147,8 @@ describe 'building definitions from given entities' do
           'kind2' => { '$ref' => '#/definitions/Kind', 'description' => 'Secondary kind.' },
           'kind3' => { '$ref' => '#/definitions/Kind', 'description' => 'Tertiary kind.' },
           'tags' => { 'type' => 'array', 'items' => { '$ref' => '#/definitions/Tag' }, 'description' => 'Tags.' },
-          'relation' => { '$ref' => '#/definitions/Relation', 'description' => 'A related model.' }
+          'relation' => { '$ref' => '#/definitions/Relation', 'description' => 'A related model.' },
+          'goodname' => { 'type' => 'string', 'description' => 'Doc name override.' }
         },
         'description' => 'This returns something'
       }

--- a/spec/support/shared_contexts/this_api.rb
+++ b/spec/support/shared_contexts/this_api.rb
@@ -25,6 +25,7 @@ shared_context 'this api' do
           expose :kind3, using: ThisApi::Entities::Kind, documentation: { desc: 'Tertiary kind.' }
           expose :tags, using: ThisApi::Entities::Tag, documentation: { desc: 'Tags.', is_array: true }
           expose :relation, using: ThisApi::Entities::Relation, documentation: { type: 'ThisApi::Relation', desc: 'A related model.' }
+          expose :override_name, documentation: { name: 'goodname', desc: 'Doc name override.' }
         end
       end
 


### PR DESCRIPTION
Example:
class ApiResponse < Grape::Entity
    expose :s, documentation: { type: String, required: true, desc: ‘description’}, as: :departure_station_code
end

Before, the document value would be:
ApiResponse {
	departure_station_code (string, optional):  description
}
Actually, if we represent a json string according to the document, say, { “departure_station_code”:”123456” }, it will get error,
We should parse {“s”:”123456”} instead.

After this change, we can write:
class ApiResponse < Grape::Entity
    expose :s, documentation: { name: ’s”, type: String, required: true, desc: ‘description’}, as: :departure_station_code
end

And the documentation generated will be:
ApiResponse {
	s (string, optional):  description
}