### PR TITLE
Fix a case when nested attribute has an alias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 #### Fixes
 
 * Your contribution here.
+* [#30](https://github.com/ruby-grape/grape-swagger-entity/pull/30): Fix nested exposures with an alias - [@Kukunin](https://github.com/Kukunin).
 
 ### 0.2.2 (November 3, 2017)
 

--- a/lib/grape-swagger/entity/parser.rb
+++ b/lib/grape-swagger/entity/parser.rb
@@ -27,19 +27,20 @@ module GrapeSwagger
         params.each_with_object({}) do |(entity_name, entity_options), memo|
           next if entity_options.fetch(:documentation, {}).fetch(:in, nil).to_s == 'header'
 
-          entity_name = entity_options[:as] if entity_options[:as]
+          final_entity_name = entity_options.fetch(:as, entity_name)
           documentation = entity_options[:documentation]
 
-          memo[entity_name] = if entity_options[:nesting]
-                                parse_nested(entity_name, entity_options, parent_model)
-                              else
-                                attribute_parser.call(entity_options)
-                              end
+          memo[final_entity_name] = if entity_options[:nesting]
+                                      parse_nested(entity_name, entity_options, parent_model)
+                                    else
+                                      attribute_parser.call(entity_options)
+                                    end
 
-          if documentation
-            memo[entity_name][:read_only] = documentation[:read_only].to_s == 'true' if documentation[:read_only]
-            memo[entity_name][:description] = documentation[:desc] if documentation[:desc]
+          next unless documentation
+          if documentation[:read_only]
+            memo[final_entity_name][:read_only] = documentation[:read_only].to_s == 'true'
           end
+          memo[final_entity_name][:description] = documentation[:desc] if documentation[:desc]
         end
       end
 
@@ -64,14 +65,12 @@ module GrapeSwagger
             items: {
               type: :object,
               properties: properties
-            },
-            description: entity_options[:desc] || ''
+            }
           }
         else
           {
             type: :object,
-            properties: properties,
-            description: entity_options[:desc] || ''
+            properties: properties
           }
         end
       end

--- a/spec/grape-swagger/entities/response_model_spec.rb
+++ b/spec/grape-swagger/entities/response_model_spec.rb
@@ -105,6 +105,9 @@ describe 'building definitions from given entities' do
             expose :some1, documentation: { type: 'String', desc: 'Nested some 1' }
             expose :some2, documentation: { type: 'String', desc: 'Nested some 2' }
           end
+          expose :a, as: :b do
+            expose :some1, documentation: { type: 'String', desc: 'Alias some 1' }
+          end
           expose :deep_nested, documentation: { type: 'Object', desc: 'Deep nested entity' } do
             expose :level_1, documentation: { type: 'Object', desc: 'More deepest nested entity' } do
               expose :level_2, documentation: { type: 'String', desc: 'Level 2' }
@@ -184,6 +187,12 @@ describe 'building definitions from given entities' do
             'some2' => { 'type' => 'string', 'description' => 'Nested some 2' }
           },
           'description' => 'Nested entity'
+        },
+        'b' => {
+          'type' => 'object',
+          'properties' => {
+            'some1' => { 'type' => 'string', 'description' => 'Alias some 1' }
+          }
         },
         'deep_nested' => {
           'type' => 'object',

--- a/spec/grape-swagger/entities/response_model_spec.rb
+++ b/spec/grape-swagger/entities/response_model_spec.rb
@@ -105,7 +105,7 @@ describe 'building definitions from given entities' do
             expose :some1, documentation: { type: 'String', desc: 'Nested some 1' }
             expose :some2, documentation: { type: 'String', desc: 'Nested some 2' }
           end
-          expose :a, as: :b do
+          expose :nested_with_alias, as: :aliased do
             expose :some1, documentation: { type: 'String', desc: 'Alias some 1' }
           end
           expose :deep_nested, documentation: { type: 'Object', desc: 'Deep nested entity' } do
@@ -188,7 +188,7 @@ describe 'building definitions from given entities' do
           },
           'description' => 'Nested entity'
         },
-        'b' => {
+        'aliased' => {
           'type' => 'object',
           'properties' => {
             'some1' => { 'type' => 'string', 'description' => 'Alias some 1' }


### PR DESCRIPTION
It crashes on `master` because it can't find original exposure