### PR TITLE
Attempt to fix required properties for nested attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 #### Fixes
 
 * Your contribution here.
+* [#31](https://github.com/ruby-grape/grape-swagger-entity/pull/31): Respect `required: true` for nested attributes as well - [@Kukunin](https://github.com/Kukunin).
 
 ### 0.2.2 (November 3, 2017)
 

--- a/lib/grape-swagger/entity/parser.rb
+++ b/lib/grape-swagger/entity/parser.rb
@@ -77,7 +77,7 @@ module GrapeSwagger
       end
 
       def required_params(params)
-        params.select { |_, options| options.dig(:documentation, :required) }
+        params.select { |_, options| options.fetch(:documentation, {}).fetch(:required, false) }
               .map { |(key, options)| [options.fetch(:as, key), options] }
               .map(&:first)
       end

--- a/lib/grape-swagger/entity/parser.rb
+++ b/lib/grape-swagger/entity/parser.rb
@@ -77,7 +77,9 @@ module GrapeSwagger
       end
 
       def required_params(params)
-        params.select { |_, options| options.dig(:documentation, :required) }.map(&:first)
+        params.select { |_, options| options.dig(:documentation, :required) }
+              .map { |(key, options)| [options.fetch(:as, key), options] }
+              .map(&:first)
       end
 
       def with_required(hash, required)

--- a/spec/grape-swagger/entities/response_model_spec.rb
+++ b/spec/grape-swagger/entities/response_model_spec.rb
@@ -110,6 +110,10 @@ describe 'building definitions from given entities' do
               expose :level_2, documentation: { type: 'String', desc: 'Level 2' }
             end
           end
+          expose :nested_required do
+            expose :some1, documentation: { required: true, desc: 'Required some 1' }
+            expose :some2, documentation: { desc: 'Optional some 2' }
+          end
 
           expose :nested_array, documentation: { type: 'Array', desc: 'Nested array' } do
             expose :id, documentation: { type: 'Integer', desc: 'Collection element id' }
@@ -197,6 +201,14 @@ describe 'building definitions from given entities' do
             }
           },
           'description' => 'Deep nested entity'
+        },
+        'nested_required' => {
+          'type' => 'object',
+          'properties' => {
+            'some1' => { 'type' => 'string', 'description' => 'Required some 1' },
+            'some2' => { 'type' => 'string', 'description' => 'Optional some 2' }
+          },
+          'required' => ['some1']
         },
         'nested_array' => {
           'type' => 'array',

--- a/spec/grape-swagger/entities/response_model_spec.rb
+++ b/spec/grape-swagger/entities/response_model_spec.rb
@@ -210,7 +210,7 @@ describe 'building definitions from given entities' do
             'some2' => { 'type' => 'string', 'description' => 'Required some 2' },
             'some3' => { 'type' => 'string', 'description' => 'Optional some 3' }
           },
-          'required' => ['some1', 'some2']
+          'required' => %w[some1 some2]
         },
         'nested_array' => {
           'type' => 'array',

--- a/spec/grape-swagger/entities/response_model_spec.rb
+++ b/spec/grape-swagger/entities/response_model_spec.rb
@@ -112,7 +112,8 @@ describe 'building definitions from given entities' do
           end
           expose :nested_required do
             expose :some1, documentation: { required: true, desc: 'Required some 1' }
-            expose :some2, documentation: { desc: 'Optional some 2' }
+            expose :attr, as: :some2, documentation: { required: true, desc: 'Required some 2' }
+            expose :some3, documentation: { desc: 'Optional some 3' }
           end
 
           expose :nested_array, documentation: { type: 'Array', desc: 'Nested array' } do
@@ -206,9 +207,10 @@ describe 'building definitions from given entities' do
           'type' => 'object',
           'properties' => {
             'some1' => { 'type' => 'string', 'description' => 'Required some 1' },
-            'some2' => { 'type' => 'string', 'description' => 'Optional some 2' }
+            'some2' => { 'type' => 'string', 'description' => 'Required some 2' },
+            'some3' => { 'type' => 'string', 'description' => 'Optional some 3' }
           },
-          'required' => ['some1']
+          'required' => ['some1', 'some2']
         },
         'nested_array' => {
           'type' => 'array',


### PR DESCRIPTION
There is another bug: `required: true` is not supported for nested attributes. I added test case but have no idea how to fix it. 

It seems there is a flaw in design: there is part in `grape-swagger` that wraps entity and adds `required` key along with `properties`. But if an attribute is nested, then `grape-swagger-entity` wraps it with the same structure as `grape-swagger`, but without required. 

Both gems does the same job, and it feels wrong