### PR TITLE
Fix issue with read_only fields

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,8 @@
 AllCops:
   Exclude:
     - vendor/**/*
+  TargetRubyVersion:
+    2.2
 
 inherit_from: .rubocop_todo.yml
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 #### Fixes
 
-* Your contribution here.
+* [#32](https://github.com/ruby-grape/grape-swagger-entity/pull/32): Fix issue with read_only fields - [@mcfilib](https://github.com/mcfilib).
 
 ### 0.2.3 (November 19, 2017)
 

--- a/grape-swagger-entity.gemspec
+++ b/grape-swagger-entity.gemspec
@@ -1,4 +1,4 @@
-lib = File.expand_path('../lib', __FILE__)
+lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'grape-swagger/entity/version'
 

--- a/lib/grape-swagger/entity/attribute_parser.rb
+++ b/lib/grape-swagger/entity/attribute_parser.rb
@@ -35,9 +35,7 @@ module GrapeSwagger
       def model_from(entity_options)
         model = entity_options[:using] if entity_options[:using].present?
 
-        if could_it_be_a_model?(entity_options[:documentation])
-          model ||= entity_options[:documentation][:type]
-        end
+        model ||= entity_options[:documentation][:type] if could_it_be_a_model?(entity_options[:documentation])
 
         model
       end

--- a/lib/grape-swagger/entity/parser.rb
+++ b/lib/grape-swagger/entity/parser.rb
@@ -38,7 +38,7 @@ module GrapeSwagger
 
           next unless documentation
           if documentation[:read_only]
-            memo[final_entity_name][:read_only] = documentation[:read_only].to_s == 'true'
+            memo[final_entity_name][:readOnly] = documentation[:read_only].to_s == 'true'
           end
           memo[final_entity_name][:description] = documentation[:desc] if documentation[:desc]
         end

--- a/lib/grape-swagger/entity/parser.rb
+++ b/lib/grape-swagger/entity/parser.rb
@@ -37,9 +37,7 @@ module GrapeSwagger
                                     end
 
           next unless documentation
-          if documentation[:read_only]
-            memo[final_entity_name][:readOnly] = documentation[:read_only].to_s == 'true'
-          end
+          memo[final_entity_name][:readOnly] = documentation[:read_only].to_s == 'true' if documentation[:read_only]
           memo[final_entity_name][:description] = documentation[:desc] if documentation[:desc]
         end
       end

--- a/spec/grape-swagger/entities/response_model_spec.rb
+++ b/spec/grape-swagger/entities/response_model_spec.rb
@@ -172,9 +172,9 @@ describe 'building definitions from given entities' do
     expect(subject['Kind']).to eql(
       'type' => 'object',
       'properties' => {
-        'id' => { 'type' => 'integer', 'format' => 'int32', 'description' => 'id of the kind.', 'enum' => [1, 2], 'read_only' => true },
-        'title' => { 'type' => 'string', 'description' => 'Title of the kind.', 'read_only' => false },
-        'type' => { 'type' => 'string', 'description' => 'Type of the kind.', 'read_only' => true }
+        'id' => { 'type' => 'integer', 'format' => 'int32', 'description' => 'id of the kind.', 'enum' => [1, 2], 'readOnly' => true },
+        'title' => { 'type' => 'string', 'description' => 'Title of the kind.', 'readOnly' => false },
+        'type' => { 'type' => 'string', 'description' => 'Type of the kind.', 'readOnly' => true }
       }
     )
     expect(subject['Tag']).to eql(

--- a/spec/grape-swagger/entities/response_model_spec.rb
+++ b/spec/grape-swagger/entities/response_model_spec.rb
@@ -48,7 +48,7 @@ describe 'responseModel' do
     expect(subject['definitions'].keys).to include 'Something'
     expect(subject['definitions']['Something']).to eq(
       'type' => 'object',
-      'description' => 'This returns something or an error',
+      'description' => 'This returns something',
       'properties' =>
           { 'text' => { 'type' => 'string', 'description' => 'Content of something.' },
             'colors' => { 'type' => 'array', 'items' => { 'type' => 'string' }, 'description' => 'Colors' },

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,4 @@
-$LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
+$LOAD_PATH.unshift File.expand_path('lib', __dir__)
 
 require 'grape-swagger/entity'
 require 'grape'


### PR DESCRIPTION
I recently tried to use the `read_only` fields feature, only to find it didn't work. As far as I can tell, this is the format as per the Swagger spec. Please see my comment in the original PR at https://github.com/ruby-grape/grape-swagger-entity/pull/26.