### PR TITLE
Fix Rubocop violations

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -18,8 +18,8 @@ Metrics/MethodLength:
   Exclude:
     - spec/**/*
 
-Style/FileName:
+Naming/FileName:
   Enabled: false
 
-Style/IndentHash:
+Layout/IndentHash:
   EnforcedStyle: consistent

--- a/lib/grape-swagger/entity/attribute_parser.rb
+++ b/lib/grape-swagger/entity/attribute_parser.rb
@@ -42,6 +42,7 @@ module GrapeSwagger
 
       def could_it_be_a_model?(value)
         return false if value.nil?
+
         direct_model_type?(value[:type]) || ambiguous_model_type?(value[:type])
       end
 
@@ -94,6 +95,7 @@ module GrapeSwagger
 
       def add_attribute_example(attribute, example)
         return unless example
+
         attribute[:example] = example.is_a?(Proc) ? example.call : example
       end
     end

--- a/lib/grape-swagger/entity/parser.rb
+++ b/lib/grape-swagger/entity/parser.rb
@@ -46,6 +46,7 @@ module GrapeSwagger
                                     end
 
           next unless documentation
+
           memo[final_entity_name][:readOnly] = documentation[:read_only].to_s == 'true' if documentation[:read_only]
           memo[final_entity_name][:description] = documentation[:desc] if documentation[:desc]
         end
@@ -92,6 +93,7 @@ module GrapeSwagger
 
       def with_required(hash, required)
         return hash if required.empty?
+
         hash[:required] = required
         hash
       end


### PR DESCRIPTION
Fixes Rubocop violations:

```
Running RuboCop...
.rubocop.yml: Style/FileName has the wrong namespace - should be Naming
.rubocop.yml: Style/IndentHash has the wrong namespace - should be Layout
Inspecting 15 files
...........CC..

Offenses:

lib/grape-swagger/entity/parser.rb:48:11: C: Layout/EmptyLineAfterGuardClause: Add empty line after guard clause.
          next unless documentation
          ^^^^^^^^^^^^^^^^^^^^^^^^^
lib/grape-swagger/entity/parser.rb:94:9: C: Layout/EmptyLineAfterGuardClause: Add empty line after guard clause.
        return hash if required.empty?
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
lib/grape-swagger/entity/attribute_parser.rb:44:9: C: Layout/EmptyLineAfterGuardClause: Add empty line after guard clause.
        return false if value.nil?
        ^^^^^^^^^^^^^^^^^^^^^^^^^^
lib/grape-swagger/entity/attribute_parser.rb:96:9: C: Layout/EmptyLineAfterGuardClause: Add empty line after guard clause.
        return unless example
        ^^^^^^^^^^^^^^^^^^^^^

15 files inspected, 4 offenses detected
RuboCop failed!
```