### PR TITLE
Add support for minItems, maxItems and uniqueItems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 #### Features
 
+* [#37](https://github.com/ruby-grape/grape-swagger-entity/pull/37): Add support for minItems, maxItems and uniqueItems - [@fotos](https://github.com/fotos).
 * Your contribution here.
 
 #### Fixes

--- a/lib/grape-swagger/entity/attribute_parser.rb
+++ b/lib/grape-swagger/entity/attribute_parser.rb
@@ -13,7 +13,17 @@ module GrapeSwagger
 
         if entity_model
           name = endpoint.nil? ? entity_model.to_s.demodulize : endpoint.send(:expose_params_from_model, entity_model)
-          return entity_model_type(name, entity_options)
+
+          entity_model_type = entity_model_type(name, entity_options)
+          return entity_model_type unless documentation
+
+          if documentation[:is_array]
+            entity_model_type[:minItems] = documentation[:min_items] if documentation.key?(:min_items)
+            entity_model_type[:maxItems] = documentation[:max_items] if documentation.key?(:max_items)
+            entity_model_type[:uniqueItems] = documentation[:unique_items] if documentation.key?(:unique_items)
+          end
+
+          entity_model_type
         else
           param = data_type_from(entity_options)
           return param unless documentation

--- a/lib/grape-swagger/entity/attribute_parser.rb
+++ b/lib/grape-swagger/entity/attribute_parser.rb
@@ -17,11 +17,7 @@ module GrapeSwagger
           entity_model_type = entity_model_type(name, entity_options)
           return entity_model_type unless documentation
 
-          if documentation[:is_array]
-            entity_model_type[:minItems] = documentation[:min_items] if documentation.key?(:min_items)
-            entity_model_type[:maxItems] = documentation[:max_items] if documentation.key?(:max_items)
-            entity_model_type[:uniqueItems] = documentation[:unique_items] if documentation.key?(:unique_items)
-          end
+          add_array_documentation(entity_model_type, documentation) if documentation[:is_array]
 
           entity_model_type
         else
@@ -37,9 +33,7 @@ module GrapeSwagger
 
           if documentation[:is_array]
             param = { type: :array, items: param }
-            param[:minItems] = documentation[:min_items] if documentation.key?(:min_items)
-            param[:maxItems] = documentation[:max_items] if documentation.key?(:max_items)
-            param[:uniqueItems] = documentation[:unique_items] if documentation.key?(:unique_items)
+            add_array_documentation(param, documentation)
           end
 
           param
@@ -113,6 +107,12 @@ module GrapeSwagger
         return unless example
 
         attribute[:example] = example.is_a?(Proc) ? example.call : example
+      end
+
+      def add_array_documentation(param, documentation)
+        param[:minItems] = documentation[:min_items] if documentation.key?(:min_items)
+        param[:maxItems] = documentation[:max_items] if documentation.key?(:max_items)
+        param[:uniqueItems] = documentation[:unique_items] if documentation.key?(:unique_items)
       end
     end
   end

--- a/lib/grape-swagger/entity/attribute_parser.rb
+++ b/lib/grape-swagger/entity/attribute_parser.rb
@@ -35,7 +35,13 @@ module GrapeSwagger
             param[:enum] = values if values.is_a?(Array)
           end
 
-          param = { type: :array, items: param } if documentation[:is_array]
+          if documentation[:is_array]
+            param = { type: :array, items: param }
+            param[:minItems] = documentation[:min_items] if documentation.key?(:min_items)
+            param[:maxItems] = documentation[:max_items] if documentation.key?(:max_items)
+            param[:uniqueItems] = documentation[:unique_items] if documentation.key?(:unique_items)
+          end
+
           param
         end
       end

--- a/spec/grape-swagger/entity/attribute_parser_spec.rb
+++ b/spec/grape-swagger/entity/attribute_parser_spec.rb
@@ -15,6 +15,24 @@ describe GrapeSwagger::Entity::AttributeParser do
 
         it { is_expected.to include('type' => 'array') }
         it { is_expected.to include('items' => { '$ref' => '#/definitions/Tag' }) }
+
+        context 'when it contains min_items' do
+          let(:entity_options) { { using: ThisApi::Entities::Tag, documentation: { is_array: true, min_items: 1 } } }
+
+          it { is_expected.to include(minItems: 1) }
+        end
+
+        context 'when it contains max_items' do
+          let(:entity_options) { { using: ThisApi::Entities::Tag, documentation: { is_array: true, max_items: 1 } } }
+
+          it { is_expected.to include(maxItems: 1) }
+        end
+
+        context 'when it contains unique_items' do
+          let(:entity_options) { { using: ThisApi::Entities::Tag, documentation: { is_array: true, unique_items: true } } }
+
+          it { is_expected.to include(uniqueItems: true) }
+        end
       end
 
       context 'when it is not exposed as an array' do

--- a/spec/grape-swagger/entity/attribute_parser_spec.rb
+++ b/spec/grape-swagger/entity/attribute_parser_spec.rb
@@ -1,0 +1,44 @@
+require 'spec_helper'
+require_relative '../../../spec/support/shared_contexts/this_api'
+
+describe GrapeSwagger::Entity::AttributeParser do
+  include_context 'this api'
+
+  describe '#call' do
+    let(:endpoint) {}
+
+    subject { described_class.new(endpoint).call(entity_options) }
+
+    context 'when the entity is a model' do
+      context 'when it is exposed as an array' do
+        let(:entity_options) { { using: ThisApi::Entities::Tag, documentation: { is_array: true } } }
+
+        it { is_expected.to include('type' => 'array') }
+        it { is_expected.to include('items' => { '$ref' => '#/definitions/Tag' }) }
+      end
+
+      context 'when it is not exposed as an array' do
+        let(:entity_options) { { using: ThisApi::Entities::Kind, documentation: { type: 'ThisApi::Kind', desc: 'The kind of this something.' } } }
+
+        it { is_expected.to_not include('type') }
+        it { is_expected.to include('$ref' => '#/definitions/Kind') }
+      end
+    end
+
+    context 'when the entity is not a model' do
+      context 'when it is exposed as an array' do
+        let(:entity_options) { { documentation: { type: 'string', desc: 'Colors', is_array: true } } }
+
+        it { is_expected.to include(type: :array) }
+        it { is_expected.to include(items: { type: 'string' }) }
+      end
+
+      context 'when it is not exposed as an array' do
+        let(:entity_options) { { documentation: { type: 'string', desc: 'Content of something.' } } }
+
+        it { is_expected.to include(type: 'string') }
+        it { is_expected.to_not include('$ref') }
+      end
+    end
+  end
+end

--- a/spec/grape-swagger/entity/attribute_parser_spec.rb
+++ b/spec/grape-swagger/entity/attribute_parser_spec.rb
@@ -49,6 +49,24 @@ describe GrapeSwagger::Entity::AttributeParser do
 
         it { is_expected.to include(type: :array) }
         it { is_expected.to include(items: { type: 'string' }) }
+
+        context 'when it contains min_items' do
+          let(:entity_options) { { documentation: { type: 'string', desc: 'Colors', is_array: true, min_items: 1 } } }
+
+          it { is_expected.to include(minItems: 1) }
+        end
+
+        context 'when it contains max_items' do
+          let(:entity_options) { { documentation: { type: 'string', desc: 'Colors', is_array: true, max_items: 1 } } }
+
+          it { is_expected.to include(maxItems: 1) }
+        end
+
+        context 'when it contains unique_items' do
+          let(:entity_options) { { documentation: { type: 'string', desc: 'Colors', is_array: true, unique_items: true } } }
+
+          it { is_expected.to include(uniqueItems: true) }
+        end
       end
 
       context 'when it is not exposed as an array' do


### PR DESCRIPTION
Adds support for `minItems`, `maxItems` and `uniqueItems` for `Arrays` (`is_array: true`) as described in the [`Schema Object` of the OpenAPI 2.0 specification](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#schema-object).

The [`grape-entity` documentation](https://github.com/ruby-grape/grape-entity/tree/v0.7.1#documentation) mentions that the `documentation` bubbles up but this is not the case for the above attributes.