### PR TITLE
Added support for hidden option for documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 #### Features
 
-* Your contribution here.
+* [#38](https://github.com/ruby-grape/grape-swagger-entity/pull/38): Added support for hidden option for documentation - [@vitoravelino](https://github.com/vitoravelino).
 
 #### Fixes
 

--- a/lib/grape-swagger/entity/parser.rb
+++ b/lib/grape-swagger/entity/parser.rb
@@ -34,7 +34,10 @@ module GrapeSwagger
         return unless params
 
         parsed = params.each_with_object({}) do |(entity_name, entity_options), memo|
-          next if entity_options.fetch(:documentation, {}).fetch(:in, nil).to_s == 'header'
+          documentation_options = entity_options.fetch(:documentation, {})
+          in_option = documentation_options.fetch(:in, nil).to_s
+          hidden_option = documentation_options.fetch(:hidden, nil)
+          next if in_option == 'header' || hidden_option == true
 
           final_entity_name = entity_options.fetch(:as, entity_name)
           documentation = entity_options[:documentation]

--- a/spec/grape-swagger/entity/parser_spec.rb
+++ b/spec/grape-swagger/entity/parser_spec.rb
@@ -24,6 +24,10 @@ describe GrapeSwagger::Entity::Parser do
         expect(properties[:message][:type]).to eq('string')
         expect(properties[:attr][:type]).to eq('string')
       end
+
+      it 'hides hidden attributes' do
+        expect(properties).to_not include(:hidden_attr)
+      end
     end
   end
 end

--- a/spec/support/shared_contexts/this_api.rb
+++ b/spec/support/shared_contexts/this_api.rb
@@ -25,6 +25,7 @@ shared_context 'this api' do
         class Something < Grape::Entity
           expose :text, documentation: { type: 'string', desc: 'Content of something.' }
           expose :colors, documentation: { type: 'string', desc: 'Colors', is_array: true }
+          expose :hidden_attr, documentation: { type: 'string', desc: 'Hidden', hidden: true }
           expose :kind, using: Kind, documentation: { type: 'ThisApi::Kind', desc: 'The kind of this something.' }
           expose :kind2, using: Kind, documentation: { desc: 'Secondary kind.' }
           expose :kind3, using: ThisApi::Entities::Kind, documentation: { desc: 'Tertiary kind.' }


### PR DESCRIPTION
Currently there's no way of avoding the exposure of an entity attribute.
Sometimes there are internal and conditional attributes that are not
important to be known in the documentation to whoever is consuming that
entity.

In this case, we are simply checking if there's a `hidden` attribute in
the `documentation` options and we skip it when parsing the entity
attributes.

Signed-off-by: Vítor Avelino <vavelino@suse.com>