### PR TITLE
Fix to avoid conflict with Polymorphic model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@
 
 * Your contribution here.
 
+### 0.3.3 (Fabruary 22, 2019)
+
+#### Features
+
+* [#39](https://github.com/ruby-grape/grape-swagger-entity/pull/39): Fix to avoid conflict with polymorphic model - [@kinoppyd](https://github.com/kinoppyd).
+
 ### 0.3.2 (January 15, 2019)
 
 #### Features


### PR DESCRIPTION
# Conflict when expose Polymorphism type definition with `as` option

## Example

Models 

```ruby
class Picture < ApplicationRecord
  belongs_to :imageable, polymorphic: true
end

class Employee < ApplicationRecord
  has_many :pictures, as: :imageable
end

class Product < ApplicationRecord
  has_many :pictures, as: :imageable
end
```

Entity

```ruby
class Entities::Employee <Grape::Entity
 # something
end

class Entities::Product <Grape::Entity
 # something
end

class Picture < Grape::Entity
  expose :imageable, as: employee, if: lambda { |ins, _| ins.kind_of?(Employee) }, using: Entities::Employee
  expose :imageable, as: product, if: lambda { |ins, _| ins.kind_of?(Product) }, using: Entities::Product
end
```

## Problems and fixes

Current parser implements don't cares about same name `expose`.

I add new inner class `Alias` and create instance to use key of `memo` hash if `:as` option enabled.
When parse grape entity params, replace `entity_name` from Alias instance to original expose name.