### PR TITLE
Add support for minLength and maxLength

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 #### Features
 
-* Your contribution here.
+* [#40](https://github.com/ruby-grape/grape-swagger-entity/pull/40): Add support for minLength and maxLength - [@fotos](https://github.com/fotos).
 
 #### Fixes
 

--- a/lib/grape-swagger/entity/attribute_parser.rb
+++ b/lib/grape-swagger/entity/attribute_parser.rb
@@ -36,6 +36,8 @@ module GrapeSwagger
             add_array_documentation(param, documentation)
           end
 
+          add_attribute_documentation(param, documentation)
+
           param
         end
       end
@@ -107,6 +109,11 @@ module GrapeSwagger
         return unless example
 
         attribute[:example] = example.is_a?(Proc) ? example.call : example
+      end
+
+      def add_attribute_documentation(param, documentation)
+        param[:minLength] = documentation[:min_length] if documentation.key?(:min_length)
+        param[:maxLength] = documentation[:max_length] if documentation.key?(:max_length)
       end
 
       def add_array_documentation(param, documentation)

--- a/spec/grape-swagger/entity/attribute_parser_spec.rb
+++ b/spec/grape-swagger/entity/attribute_parser_spec.rb
@@ -44,6 +44,24 @@ describe GrapeSwagger::Entity::AttributeParser do
     end
 
     context 'when the entity is not a model' do
+      context 'when it is exposed as a string' do
+        let(:entity_options) { { documentation: { type: 'string', desc: 'Colors' } } }
+
+        it { is_expected.to include(type: 'string') }
+
+        context 'when it contains min_length' do
+          let(:entity_options) { { documentation: { type: 'string', desc: 'Colors', min_length: 1 } } }
+
+          it { is_expected.to include(minLength: 1) }
+        end
+
+        context 'when it contains max_length' do
+          let(:entity_options) { { documentation: { type: 'string', desc: 'Colors', max_length: 1 } } }
+
+          it { is_expected.to include(maxLength: 1) }
+        end
+      end
+
       context 'when it is exposed as an array' do
         let(:entity_options) { { documentation: { type: 'string', desc: 'Colors', is_array: true } } }
 


### PR DESCRIPTION
Adds support for `minLength`, `maxLength` for `Strings` (`type: String`) as described in the [`Schema Object` of the OpenAPI 2.0 specification](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#schema-object).

This is very similar to #37.