### PR TITLE
Update rubocop gem to version ~> 0.68.1

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -21,5 +21,5 @@ Metrics/MethodLength:
 Naming/FileName:
   Enabled: false
 
-Layout/IndentHash:
+Layout/IndentFirstHashElement:
   EnforcedStyle: consistent

--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ group :development, :test do
   gem 'rake'
   gem 'rdoc'
   gem 'rspec', '~> 3.0'
-  gem 'rubocop', '~> 0.48'
+  gem 'rubocop', '~> 0.68.1'
 end
 
 gem 'grape-swagger', git: 'https://github.com/ruby-grape/grape-swagger.git'


### PR DESCRIPTION
Fixes build by updating and locking `rubocop` gem to version `~> 0.68.1`.

Version `0.68.1` is the last version that supports Ruby `2.2`, since [version `0.69.0` dropped](https://github.com/rubocop-hq/rubocop/blob/v0.69.0/CHANGELOG.md#changes) Ruby `2.2` support in https://github.com/rubocop-hq/rubocop/issues/6945.

Additionally `Layout/IndentHash` has been [renamed to `IndentFirstHashElement` in `0.68.0`](https://github.com/rubocop-hq/rubocop/blob/v0.68.0/CHANGELOG.md#changes).

We should probably consider dropping support for Ruby `2.2`, in a separate MR, since it has [reached EOL](https://www.ruby-lang.org/en/news/2018/06/20/support-of-ruby-2-2-has-ended/) since March 2018.