### PR TITLE
fixed issue where a boolean example value of false would not display in swagger file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 #### Fixes
 
-* Your contribution here.
+[#46](https://github.com/ruby-grape/grape-swagger-entity/pull/46): Fixed issue where a boolean example value of false would not display in swagger file - [@drewnichols](https://github.com/drewnichols).
 
 ### 0.3.4 (January 9, 2020)
 

--- a/lib/grape-swagger/entity/attribute_parser.rb
+++ b/lib/grape-swagger/entity/attribute_parser.rb
@@ -24,8 +24,8 @@ module GrapeSwagger
           param = data_type_from(entity_options)
           return param unless documentation
 
-          param[:default] = documentation[:default] if documentation[:default]
-          add_attribute_example(param, documentation[:example])
+          add_attribute_sample(param, documentation, :default)
+          add_attribute_sample(param, documentation, :example)
 
           if (values = documentation[:values])
             param[:enum] = values if values.is_a?(Array)
@@ -105,10 +105,11 @@ module GrapeSwagger
         end
       end
 
-      def add_attribute_example(attribute, example)
-        return unless example
+      def add_attribute_sample(attribute, hash, key)
+        value = hash[key]
+        return if value.nil?
 
-        attribute[:example] = example.is_a?(Proc) ? example.call : example
+        attribute[key] = value.is_a?(Proc) ? value.call : value
       end
 
       def add_attribute_documentation(param, documentation)

--- a/spec/grape-swagger/entity/attribute_parser_spec.rb
+++ b/spec/grape-swagger/entity/attribute_parser_spec.rb
@@ -93,6 +93,22 @@ describe GrapeSwagger::Entity::AttributeParser do
         it { is_expected.to include(type: 'string') }
         it { is_expected.to_not include('$ref') }
       end
+
+      context 'when it is exposed as a boolean' do
+        let(:entity_options) { { documentation: { type: 'boolean', example: example_value, default: example_value } } }
+
+        context 'when the example value is true' do
+          let(:example_value) { true }
+
+          it { is_expected.to include(type: 'boolean', example: example_value, default: example_value) }
+        end
+
+        context 'when the example value is false' do
+          let(:example_value) { false }
+
+          it { is_expected.to include(type: 'boolean', example: example_value, default: example_value) }
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Fix for issue https://github.com/ruby-grape/grape-swagger-entity/issues/45