### PR TITLE
Features/inheritance and discriminator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,7 @@
 #### Features
 
 * Your contribution here.
-
-#### Features
-
-* Your contribution here.
+* [#50](https://github.com/ruby-grape/grape-swagger-entity/pull/50): Features/inheritance and discriminator - [@MaximeRDY](https://github.com/MaximeRDY).
 
 ### 0.4.0 (May 30, 2020)
 

--- a/lib/grape-swagger/entity.rb
+++ b/lib/grape-swagger/entity.rb
@@ -2,6 +2,7 @@ require 'grape-swagger'
 require 'grape-entity'
 
 require 'grape-swagger/entity/version'
+require 'grape-swagger/entity/helper'
 require 'grape-swagger/entity/attribute_parser'
 require 'grape-swagger/entity/parser'
 

--- a/lib/grape-swagger/entity/attribute_parser.rb
+++ b/lib/grape-swagger/entity/attribute_parser.rb
@@ -12,7 +12,7 @@ module GrapeSwagger
         entity_model = model_from(entity_options)
 
         if entity_model
-          name = endpoint.nil? ? entity_model.to_s.demodulize : endpoint.send(:expose_params_from_model, entity_model)
+          name = GrapeSwagger::Entity::Helper.model_name(entity_model, endpoint)
 
           entity_model_type = entity_model_type(name, entity_options)
           return entity_model_type unless documentation

--- a/lib/grape-swagger/entity/attribute_parser.rb
+++ b/lib/grape-swagger/entity/attribute_parser.rb
@@ -39,7 +39,7 @@ module GrapeSwagger
           add_attribute_documentation(param, documentation)
 
           add_extension_documentation(param, documentation)
-
+          add_discriminator_extension(param, documentation)
           param
         end
       end
@@ -127,6 +127,10 @@ module GrapeSwagger
 
       def add_extension_documentation(param, documentation)
         GrapeSwagger::DocMethods::Extensions.add_extensions_to_root(documentation, param)
+      end
+
+      def add_discriminator_extension(param, documentation)
+        param[:documentation] = { is_discriminator: true } if documentation.key?(:is_discriminator)
       end
     end
   end

--- a/lib/grape-swagger/entity/helper.rb
+++ b/lib/grape-swagger/entity/helper.rb
@@ -13,7 +13,7 @@ module GrapeSwagger
 
         def discriminator(entity_model)
           entity_model.superclass.root_exposures.detect do |value|
-            value.documentation.try(:[], :is_discriminator)
+            value.documentation.dig(:is_discriminator)
           end
         end
 

--- a/lib/grape-swagger/entity/helper.rb
+++ b/lib/grape-swagger/entity/helper.rb
@@ -1,0 +1,13 @@
+module GrapeSwagger
+  module Entity
+    class Helper
+      def self.model_name(entity_model, endpoint)
+        if endpoint.nil?
+          entity_model.to_s.demodulize
+        else
+          endpoint.send(:expose_params_from_model, entity_model)
+        end
+      end
+    end
+  end
+end

--- a/lib/grape-swagger/entity/helper.rb
+++ b/lib/grape-swagger/entity/helper.rb
@@ -1,11 +1,34 @@
 module GrapeSwagger
   module Entity
+    # Helper methods for DRY
     class Helper
-      def self.model_name(entity_model, endpoint)
-        if endpoint.nil?
-          entity_model.to_s.demodulize
-        else
-          endpoint.send(:expose_params_from_model, entity_model)
+      class << self
+        def model_name(entity_model, endpoint)
+          if endpoint.nil?
+            entity_model.to_s.demodulize
+          else
+            endpoint.send(:expose_params_from_model, entity_model)
+          end
+        end
+
+        def discriminator(entity_model)
+          entity_model.superclass.root_exposures.detect do |value|
+            value.documentation.try(:[], :is_discriminator)
+          end
+        end
+
+        def root_exposures_without_parent(entity_model)
+          entity_model.root_exposures.select do |value|
+            entity_model.superclass.root_exposures.find_by(value.attribute).nil?
+          end
+        end
+
+        def root_exposure_with_discriminator(entity_model)
+          if discriminator(entity_model)
+            root_exposures_without_parent(entity_model)
+          else
+            entity_model.root_exposures
+          end
         end
       end
     end

--- a/lib/grape-swagger/entity/parser.rb
+++ b/lib/grape-swagger/entity/parser.rb
@@ -47,7 +47,7 @@ module GrapeSwagger
 
       def superclass_contains_discriminator?(exposure)
         exposure.superclass.root_exposures.detect do |value|
-          value.documentation[:is_discriminator]
+          value.documentation.try(:[], :is_discriminator)
         end
       end
 

--- a/spec/grape-swagger/entity/parser_spec.rb
+++ b/spec/grape-swagger/entity/parser_spec.rb
@@ -62,8 +62,13 @@ describe GrapeSwagger::Entity::Parser do
         it 'parses the model with allOf' do
           expect(properties).to include(:allOf)
           all_of = properties[:allOf]
+          child_property = all_of.last.first
+          child_required = all_of.last.last
           expect(all_of.first['$ref']).to eq('#/definitions/Parent')
-          expect(all_of.last.first[:name][:type]).to eq('string')
+          expect(child_property[:name][:type]).to eq('string')
+          expect(child_property[:type][:type]).to eq('string')
+          expect(child_property[:type][:enum]).to eq(['Child'])
+          expect(child_required).to include(:type)
         end
       end
     end

--- a/spec/grape-swagger/entity/parser_spec.rb
+++ b/spec/grape-swagger/entity/parser_spec.rb
@@ -2,31 +2,69 @@ require 'spec_helper'
 require_relative '../../../spec/support/shared_contexts/this_api'
 
 describe GrapeSwagger::Entity::Parser do
-  include_context 'this api'
+  context 'this api' do
+    include_context 'this api'
 
-  describe '#call' do
-    let(:parsed_entity) { described_class.new(ThisApi::Entities::Something, endpoint).call }
-    let(:properties) { parsed_entity.first }
-    let(:required) { parsed_entity.last }
+    describe '#call' do
+      let(:parsed_entity) { described_class.new(ThisApi::Entities::Something, endpoint).call }
+      let(:properties) { parsed_entity.first }
+      let(:required) { parsed_entity.last }
 
-    context 'when no endpoint is passed' do
-      let(:endpoint) { nil }
+      context 'when no endpoint is passed' do
+        let(:endpoint) { nil }
 
-      it 'parses the model with the correct :using definition' do
-        expect(properties[:kind]['$ref']).to eq('#/definitions/Kind')
-        expect(properties[:kind2]['$ref']).to eq('#/definitions/Kind')
-        expect(properties[:kind3]['$ref']).to eq('#/definitions/Kind')
+        it 'parses the model with the correct :using definition' do
+          expect(properties[:kind]['$ref']).to eq('#/definitions/Kind')
+          expect(properties[:kind2]['$ref']).to eq('#/definitions/Kind')
+          expect(properties[:kind3]['$ref']).to eq('#/definitions/Kind')
+        end
+
+        it 'merges attributes that have merge: true defined' do
+          expect(properties[:merged_attribute]).to be_nil
+          expect(properties[:code][:type]).to eq('string')
+          expect(properties[:message][:type]).to eq('string')
+          expect(properties[:attr][:type]).to eq('string')
+        end
+
+        it 'hides hidden attributes' do
+          expect(properties).to_not include(:hidden_attr)
+        end
       end
+    end
+  end
+  context 'inheritance api' do
+    include_context 'inheritance api'
 
-      it 'merges attributes that have merge: true defined' do
-        expect(properties[:merged_attribute]).to be_nil
-        expect(properties[:code][:type]).to eq('string')
-        expect(properties[:message][:type]).to eq('string')
-        expect(properties[:attr][:type]).to eq('string')
+    describe '#call for Parent' do
+      let(:parsed_entity) do
+        described_class.new(InheritanceApi::Entities::Parent, endpoint).call
       end
+      let(:properties) { parsed_entity.first }
 
-      it 'hides hidden attributes' do
-        expect(properties).to_not include(:hidden_attr)
+      context 'when no endpoint is passed' do
+        let(:endpoint) { nil }
+
+        it 'parses the model with discriminator' do
+          expect(properties[:type][:documentation]).to eq(is_discriminator: true)
+        end
+      end
+    end
+
+    describe '#call for Child' do
+      let(:parsed_entity) do
+        described_class.new(InheritanceApi::Entities::Child, endpoint).call
+      end
+      let(:properties) { parsed_entity }
+
+      context 'when no endpoint is passed' do
+        let(:endpoint) { nil }
+
+        it 'parses the model with allOf' do
+          expect(properties).to include(:allOf)
+          all_of = properties[:allOf]
+          expect(all_of.first['$ref']).to eq('#/definitions/Parent')
+          expect(all_of.last.first[:name][:type]).to eq('string')
+        end
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,6 +7,7 @@ Bundler.setup :default, :test
 
 require 'rack'
 require 'rack/test'
+require 'pry'
 
 RSpec.configure do |config|
   require 'rspec/expectations'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,7 +7,6 @@ Bundler.setup :default, :test
 
 require 'rack'
 require 'rack/test'
-require 'pry'
 
 RSpec.configure do |config|
   require 'rspec/expectations'

--- a/spec/support/shared_contexts/inheritance_api.rb
+++ b/spec/support/shared_contexts/inheritance_api.rb
@@ -1,0 +1,16 @@
+shared_context 'inheritance api' do
+  before :all do
+    module InheritanceApi
+      module Entities
+        class Parent < Grape::Entity
+          expose :type, documentation: { type: 'string', is_discriminator: true, required: true }
+          expose :id, documentation: { type: 'integer' }
+        end
+
+        class Child < Parent
+          expose :name, documentation: { type: 'string', desc: 'Name' }
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Hi,

I would like to add inheritance with discriminator like that:
```
 class Pet < Grape::Entity
          expose :type, documentation: {
            type: 'string',
            is_discriminator: true,
            required: true
          }
          expose :name, documentation: {
            type: 'string',
            required: true
          }
        end

        class Cat < Pet
          expose :huntingSkill, documentation: {
            type: 'string',
            description: 'The measured skill for hunting',
            default: 'lazy',
            values: %w[
              clueless
              lazy
              adventurous
              aggressive
            ]
          }
```
Need this PR : https://github.com/ruby-grape/grape-swagger/pull/793