### PR TITLE
Properly render `example` for array exposure done using another entity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 #### Fixes
 
 * [#67](https://github.com/ruby-grape/grape-swagger-entity/pull/67): Various build updates - [@mscrivo](https://github.com/mscrivo).
+* [#68](https://github.com/ruby-grape/grape-swagger-entity/pull/68): Properly render `example` for array exposure done using another entity - [@magni-](https://github.com/magni-).
 * Your contribution here.
 
 ### 0.5.3 (2024/02/02)

--- a/lib/grape-swagger/entity/attribute_parser.rb
+++ b/lib/grape-swagger/entity/attribute_parser.rb
@@ -33,10 +33,7 @@ module GrapeSwagger
             param[:enum] = values
           end
 
-          if documentation[:is_array]
-            param = { type: :array, items: param }
-            add_array_documentation(param, documentation)
-          end
+          add_array_documentation(param, documentation) if documentation[:is_array]
 
           add_attribute_sample(param, documentation, :default)
           add_attribute_sample(param, documentation, :example)
@@ -81,7 +78,16 @@ module GrapeSwagger
 
         data_type = GrapeSwagger::DocMethods::DataType.call(documented_type)
 
-        document_data_type(documentation[:documentation], data_type)
+        documented_data_type = document_data_type(documentation[:documentation], data_type)
+
+        if documentation[:documentation] && documentation[:documentation][:is_array]
+          {
+            type: :array,
+            items: documented_data_type
+          }
+        else
+          documented_data_type
+        end
       end
 
       def document_data_type(documentation, data_type)

--- a/lib/grape-swagger/entity/attribute_parser.rb
+++ b/lib/grape-swagger/entity/attribute_parser.rb
@@ -10,13 +10,12 @@ module GrapeSwagger
       end
 
       def call(entity_options)
-        param =
-          if (entity_model = model_from(entity_options))
-            name = GrapeSwagger::Entity::Helper.model_name(entity_model, endpoint)
-            entity_model_type(name, entity_options)
-          else
-            data_type_from(entity_options)
-          end
+        param = if (entity_model = model_from(entity_options))
+                  name = GrapeSwagger::Entity::Helper.model_name(entity_model, endpoint)
+                  entity_model_type(name, entity_options)
+                else
+                  data_type_from(entity_options)
+                end
 
         documentation = entity_options[:documentation]
         return param if documentation.nil?

--- a/lib/grape-swagger/entity/attribute_parser.rb
+++ b/lib/grape-swagger/entity/attribute_parser.rb
@@ -10,40 +10,31 @@ module GrapeSwagger
       end
 
       def call(entity_options)
-        documentation = entity_options[:documentation]
-        entity_model = model_from(entity_options)
-
-        if entity_model
-          name = GrapeSwagger::Entity::Helper.model_name(entity_model, endpoint)
-
-          entity_model_type = entity_model_type(name, entity_options)
-          return entity_model_type unless documentation
-
-          add_extension_documentation(entity_model_type, documentation)
-          add_array_documentation(entity_model_type, documentation) if documentation[:is_array]
-
-          add_attribute_sample(entity_model_type, documentation, :example)
-
-          entity_model_type
-        else
-          param = data_type_from(entity_options)
-          return param unless documentation
-
-          if (values = documentation[:values]) && values.is_a?(Array)
-            param[:enum] = values
+        param =
+          if (entity_model = model_from(entity_options))
+            name = GrapeSwagger::Entity::Helper.model_name(entity_model, endpoint)
+            entity_model_type(name, entity_options)
+          else
+            data_type_from(entity_options)
           end
 
-          add_array_documentation(param, documentation) if documentation[:is_array]
+        documentation = entity_options[:documentation]
+        return param if documentation.nil?
 
-          add_attribute_sample(param, documentation, :default)
-          add_attribute_sample(param, documentation, :example)
-
-          add_attribute_documentation(param, documentation)
-
-          add_extension_documentation(param, documentation)
-          add_discriminator_extension(param, documentation)
-          param
+        if (values = documentation[:values]) && values.is_a?(Array)
+          param[:enum] = values
         end
+
+        add_array_documentation(param, documentation) if documentation[:is_array]
+
+        add_attribute_sample(param, documentation, :default)
+        add_attribute_sample(param, documentation, :example)
+
+        add_attribute_documentation(param, documentation)
+
+        add_extension_documentation(param, documentation)
+        add_discriminator_extension(param, documentation)
+        param
       end
 
       private

--- a/lib/grape-swagger/entity/attribute_parser.rb
+++ b/lib/grape-swagger/entity/attribute_parser.rb
@@ -22,6 +22,8 @@ module GrapeSwagger
           add_extension_documentation(entity_model_type, documentation)
           add_array_documentation(entity_model_type, documentation) if documentation[:is_array]
 
+          add_attribute_sample(entity_model_type, documentation, :example)
+
           entity_model_type
         else
           param = data_type_from(entity_options)

--- a/spec/grape-swagger/entity/attribute_parser_spec.rb
+++ b/spec/grape-swagger/entity/attribute_parser_spec.rb
@@ -18,6 +18,23 @@ describe GrapeSwagger::Entity::AttributeParser do
         it { is_expected.to include('type' => 'array') }
         it { is_expected.to include('items' => { '$ref' => '#/definitions/Tag' }) }
 
+        context 'when it contains example' do
+          let(:entity_options) do
+            {
+              using: ThisApi::Entities::Tag,
+              documentation: {
+                is_array: true,
+                example: [
+                  { name: 'green' },
+                  { name: 'blue' }
+                ]
+              }
+            }
+          end
+
+          it { is_expected.to include(example: %w[green blue].map { { name: _1 } }) }
+        end
+
         context 'when it contains min_items' do
           let(:entity_options) { { using: ThisApi::Entities::Tag, documentation: { is_array: true, min_items: 1 } } }
 


### PR DESCRIPTION
Right now the `example` documentation key is ignored. The first commit on its own fixes this, but then I opted to refactor `AttributeParser#call` to make it harder to miss adding support for a documentation key for a `using` exposure.