### PR TITLE
Add support for minimum and maximum

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -58,6 +58,7 @@ Metrics/BlockLength:
 # Configuration parameters: CountComments, Max, CountAsOne.
 Metrics/ClassLength:
   Exclude:
+    - 'lib/grape-swagger/entity/attribute_parser.rb'
     - 'lib/grape-swagger/entity/parser.rb'
 
 # Offense count: 2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 #### Features
 
+* [#69](https://github.com/ruby-grape/grape-swagger-entity/pull/67): Add support for minimum and maximum - [@storey](https://github.com/storey).
 * Your contribution here.
 
 #### Fixes

--- a/lib/grape-swagger/entity/attribute_parser.rb
+++ b/lib/grape-swagger/entity/attribute_parser.rb
@@ -115,6 +115,15 @@ module GrapeSwagger
       end
 
       def add_attribute_documentation(param, documentation)
+        param[:minimum] = documentation[:minimum] if documentation.key?(:minimum)
+        param[:maximum] = documentation[:maximum] if documentation.key?(:maximum)
+
+        values = documentation[:values]
+        if values&.is_a?(Range)
+          param[:minimum] = values.begin if values.begin.is_a?(Numeric)
+          param[:maximum] = values.end if values.end.is_a?(Numeric)
+        end
+
         param[:minLength] = documentation[:min_length] if documentation.key?(:min_length)
         param[:maxLength] = documentation[:max_length] if documentation.key?(:max_length)
       end

--- a/spec/grape-swagger/entity/attribute_parser_spec.rb
+++ b/spec/grape-swagger/entity/attribute_parser_spec.rb
@@ -86,7 +86,7 @@ describe GrapeSwagger::Entity::AttributeParser do
         end
 
         context 'when it contains values array' do
-          let(:entity_options) { { documentation: { type: 'string', desc: 'Colors', values: ['red', 'blue'] } } }
+          let(:entity_options) { { documentation: { type: 'string', desc: 'Colors', values: %w[red blue] } } }
 
           it { is_expected.to_not include('minimum') }
           it { is_expected.to_not include('maximum') }

--- a/spec/grape-swagger/entity/attribute_parser_spec.rb
+++ b/spec/grape-swagger/entity/attribute_parser_spec.rb
@@ -85,8 +85,110 @@ describe GrapeSwagger::Entity::AttributeParser do
           it { is_expected.to include(maxLength: 1) }
         end
 
+        context 'when it contains values array' do
+          let(:entity_options) { { documentation: { type: 'string', desc: 'Colors', values: ['red', 'blue'] } } }
+
+          it { is_expected.to_not include('minimum') }
+          it { is_expected.to_not include('maximum') }
+        end
+
+        context 'when it contains values range' do
+          let(:entity_options) { { documentation: { type: 'string', desc: 'Colors', values: 'a'...'c' } } }
+
+          it { is_expected.to_not include('minimum') }
+          it { is_expected.to_not include('maximum') }
+        end
+
         context 'when it contains extensions' do
           let(:entity_options) { { documentation: { type: 'string', desc: 'Colors', x: { some: 'stuff' } } } }
+
+          it { is_expected.to include('x-some' => 'stuff') }
+        end
+      end
+
+      context 'when it is exposed as a number' do
+        let(:entity_options) { { documentation: { type: 'number', desc: 'Solution pH' } } }
+
+        it { is_expected.to include(type: 'number') }
+
+        context 'when it contains minimum' do
+          let(:entity_options) { { documentation: { type: 'number', desc: 'Solution pH', minimum: 2.5 } } }
+
+          it { is_expected.to include(minimum: 2.5) }
+        end
+
+        context 'when it contains maximum' do
+          let(:entity_options) { { documentation: { type: 'number', desc: 'Solution pH', maximum: 9.1 } } }
+
+          it { is_expected.to include(maximum: 9.1) }
+        end
+
+        context 'when it contains values array' do
+          let(:entity_options) { { documentation: { type: 'number', desc: 'Solution pH', values: [6.0, 7.0, 8.0] } } }
+
+          it { is_expected.to_not include('minimum') }
+          it { is_expected.to_not include('maximum') }
+        end
+
+        context 'when it contains values range' do
+          let(:entity_options) { { documentation: { type: 'number', desc: 'Solution pH', values: 0.0..14.0 } } }
+
+          it { is_expected.to include(minimum: 0.0, maximum: 14.0) }
+        end
+
+        context 'when it contains values range with no minimum' do
+          let(:entity_options) { { documentation: { type: 'number', desc: 'Solution pH', values: ..14.0 } } }
+
+          it { is_expected.to_not include('minimum') }
+          it { is_expected.to include(maximum: 14.0) }
+        end
+
+        context 'when it contains values range with no maximum' do
+          let(:entity_options) { { documentation: { type: 'number', desc: 'Solution pH', values: 0.0.. } } }
+
+          it { is_expected.to_not include('maximum') }
+          it { is_expected.to include(minimum: 0.0) }
+        end
+
+        context 'when it contains extensions' do
+          let(:entity_options) { { documentation: { type: 'number', desc: 'Solution pH', x: { some: 'stuff' } } } }
+
+          it { is_expected.to include('x-some' => 'stuff') }
+        end
+      end
+
+      context 'when it is exposed as an integer' do
+        let(:entity_options) { { documentation: { type: 'integer', desc: 'Count' } } }
+
+        it { is_expected.to include(type: 'integer') }
+
+        context 'when it contains minimum' do
+          let(:entity_options) { { documentation: { type: 'integer', desc: 'Count', minimum: 2 } } }
+
+          it { is_expected.to include(minimum: 2) }
+        end
+
+        context 'when it contains maximum' do
+          let(:entity_options) { { documentation: { type: 'integer', desc: 'Count', maximum: 100 } } }
+
+          it { is_expected.to include(maximum: 100) }
+        end
+
+        context 'when it contains values array' do
+          let(:entity_options) { { documentation: { type: 'integer', desc: 'Count', values: 1..10 } } }
+
+          it { is_expected.to_not include('minimum') }
+          it { is_expected.to_not include('maximum') }
+        end
+
+        context 'when it contains values range' do
+          let(:entity_options) { { documentation: { type: 'integer', desc: 'Count', values: 1..10 } } }
+
+          it { is_expected.to include(minimum: 1, maximum: 10) }
+        end
+
+        context 'when it contains extensions' do
+          let(:entity_options) { { documentation: { type: 'integer', desc: 'Count', x: { some: 'stuff' } } } }
 
           it { is_expected.to include('x-some' => 'stuff') }
         end


### PR DESCRIPTION
This adds [support for generating the `minimum` and `maximum` swagger keywords](https://swagger.io/docs/specification/data-models/data-types/#range). 

There are two ways to produce these keywords:
### 1. Explicitly set a `minimum` or `maximum` property in the `documentation` object
```
documentation: {
  minimum: 0,
  maximum: 100,
}
```
### 2. Set the `values` property in the `documentation` object to a numeric range (which matches grape's built in validation for numeric min + max)
```
documentation: {
  values: 0..100,
}
```