### PR TITLE
Fix enum values of array attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 #### Fixes
 
 * Your contribution here.
+* [#71](https://github.com/ruby-grape/grape-swagger-entity/pull/71): Fix regression for enum values in array attributes - [@Jell](https://github.com/Jell).
 
 ### 0.5.4 (2024/04/19)
 

--- a/lib/grape-swagger/entity/attribute_parser.rb
+++ b/lib/grape-swagger/entity/attribute_parser.rb
@@ -20,10 +20,6 @@ module GrapeSwagger
         documentation = entity_options[:documentation]
         return param if documentation.nil?
 
-        if (values = documentation[:values]) && values.is_a?(Array)
-          param[:enum] = values
-        end
-
         add_array_documentation(param, documentation) if documentation[:is_array]
 
         add_attribute_sample(param, documentation, :default)
@@ -62,15 +58,15 @@ module GrapeSwagger
           !type == Array
       end
 
-      def data_type_from(documentation)
-        documented_type = documentation[:type]
-        documented_type ||= documentation[:documentation] && documentation[:documentation][:type]
+      def data_type_from(entity_options)
+        documentation = entity_options[:documentation] || {}
+        documented_type = entity_options[:type] || documentation[:type]
 
         data_type = GrapeSwagger::DocMethods::DataType.call(documented_type)
 
-        documented_data_type = document_data_type(documentation[:documentation], data_type)
+        documented_data_type = document_data_type(documentation, data_type)
 
-        if documentation[:documentation] && documentation[:documentation][:is_array]
+        if documentation[:is_array]
           {
             type: :array,
             items: documented_data_type
@@ -87,7 +83,12 @@ module GrapeSwagger
                else
                  { type: data_type }
                end
-        type[:format] = documentation[:format] if documentation&.key?(:format)
+
+        type[:format] = documentation[:format] if documentation.key?(:format)
+
+        if (values = documentation[:values]) && values.is_a?(Array)
+          type[:enum] = values
+        end
 
         type
       end

--- a/spec/grape-swagger/entity/attribute_parser_spec.rb
+++ b/spec/grape-swagger/entity/attribute_parser_spec.rb
@@ -227,6 +227,14 @@ describe GrapeSwagger::Entity::AttributeParser do
 
           it { is_expected.to include(uniqueItems: true) }
         end
+
+        context 'when it contains values array' do
+          let(:entity_options) do
+            { documentation: { type: 'string', desc: 'Colors', is_array: true, values: %w[red blue] } }
+          end
+
+          it { is_expected.to eq(type: :array, items: { type: 'string', enum: %w[red blue] }) }
+        end
       end
 
       context 'when it is not exposed as an array' do


### PR DESCRIPTION
This bug was introduced in
https://github.com/ruby-grape/grape-swagger-entity/pull/68

I've added a regression spec and a fix for this, along with a tiny bit of cleanup because there seem to have been some confusion in the naming of variables.