### PR TITLE
Ensure inherited nested exposures are merged

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 #### Fixes
 
 * Your contribution here.
+* [#72](https://github.com/ruby-grape/grape-swagger-entity/pull/72): Ensure inherited nested exposures are merged - [@pirhoo](https://github.com/pirhoo)
 * [#71](https://github.com/ruby-grape/grape-swagger-entity/pull/71): Fix regression for enum values in array attributes - [@Jell](https://github.com/Jell).
 
 ### 0.5.4 (2024/04/19)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 #### Fixes
 
 * Your contribution here.
-* [#72](https://github.com/ruby-grape/grape-swagger-entity/pull/72): Ensure inherited nested exposures are merged - [@pirhoo](https://github.com/pirhoo)
+* [#72](https://github.com/ruby-grape/grape-swagger-entity/pull/72): Ensure inherited nested exposures are merged - [@pirhoo](https://github.com/pirhoo).
 * [#71](https://github.com/ruby-grape/grape-swagger-entity/pull/71): Fix regression for enum values in array attributes - [@Jell](https://github.com/Jell).
 
 ### 0.5.4 (2024/04/19)


### PR DESCRIPTION
Hello,

This PR want to fix a limitation of this gem with nested expose on child entities.

## Problem

I noticed that when an entity inherits from another, nested exposures are not merged (as opposed to Grape Entity) in the definition object. For instance this won't work:

```ruby
class Nested < Grape::Entity
  expose :nested, documentation: { type: Hash, desc: 'Nested entity' } do
    expose :some1, documentation: { type: 'String', desc: 'Nested some 1' }
    expose :some2, documentation: { type: 'String', desc: 'Nested some 2' }
  end
end

class NestedChild < Nested
  expose :nested, documentation: { type: Hash, desc: 'Nested entity' } do
    expose :some3, documentation: { type: 'String', desc: 'Nested some 3' }
  end
end
```

Would produce this definition:

```json
{
  "definitions": {
    "Nested": {
      "type": "object",
      "properties": {
        "nested": {
          "type": "object",
          "properties": {
            "some1": {
              "type": "string",
              "description": "Nested some 1"
            },
            "some2": {
              "type": "string",
              "description": "Nested some 2"
            }
          },
          "description": "Nested entity"
        }
      }
    },
    "NestedChild": {
      "type": "object",
      "properties": {
        "nested": {
          "type": "object",
          "properties": {
            "some1": {
              "type": "string",
              "description": "Nested some 1"
            },
            "some2": {
              "type": "string",
              "description": "Nested some 2"
            }
          },
          "description": "Nested entity"
        }
      }
    }
  }
}
```

## Solution

Instead of listing params from the first match of a given property (with `find_by`) we use all exposed properties on the current model (with `select_by`). This allows to get exposed properties both from `Nested` and `NestedChild`.

With those changes, the new property "some3" is now visible in the definition:

```json
{
  "definitions": {
    "Nested": {
      "type": "object",
      "properties": {
        "nested": {
          "type": "object",
          "properties": {
            "some1": {
              "type": "string",
              "description": "Nested some 1"
            },
            "some2": {
              "type": "string",
              "description": "Nested some 2"
            }
          },
          "description": "Nested entity"
        }
      }
    },
    "NestedChild": {
      "type": "object",
      "properties": {
        "nested": {
          "type": "object",
          "properties": {
            "some1": {
              "type": "string",
              "description": "Nested some 1"
            },
            "some2": {
              "type": "string",
              "description": "Nested some 2"
            },
            "some3": {
              "type": "string",
              "description": "Nested some 3"
            }
          },
          "description": "Nested entity"
        }
      }
    }
  }
}
```

Thanks!
