### PR TITLE
Fix Correctly handle class types like Time in documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 #### Fixes
 
 * Your contribution here.
+* [#79](https://github.com/ruby-grape/grape-swagger-entity/pull/79): Fix correctly handle class types like time in documentation - [@krororo](https://github.com/krororo).
 
 ### 0.6.0 (2025/04/26)
 

--- a/lib/grape-swagger/entity/attribute_parser.rb
+++ b/lib/grape-swagger/entity/attribute_parser.rb
@@ -60,11 +60,9 @@ module GrapeSwagger
       end
 
       def primitive_type?(type)
-        type_name = type.name&.downcase
-        return false if type_name.nil?
-
-        GrapeSwagger::DocMethods::DataType.primitive?(type_name) ||
-          ADDITIONAL_PRIMITIVE_TYPES.include?(type_name)
+        data_type = GrapeSwagger::DocMethods::DataType.call(type)
+        GrapeSwagger::DocMethods::DataType.primitive?(data_type) ||
+          ADDITIONAL_PRIMITIVE_TYPES.include?(data_type)
       end
 
       def data_type_from(entity_options)

--- a/spec/grape-swagger/entities/response_model_spec.rb
+++ b/spec/grape-swagger/entities/response_model_spec.rb
@@ -54,6 +54,7 @@ describe 'responseModel' do
       'properties' =>
           { 'text' => { 'type' => 'string', 'description' => 'Content of something.' },
             'colors' => { 'type' => 'array', 'items' => { 'type' => 'string' }, 'description' => 'Colors' },
+            'created_at' => { 'type' => 'string', 'format' => 'date-time', 'description' => 'Created at the time.' },
             'kind' => { '$ref' => '#/definitions/ThisApi_Entities_Kind',
                         'description' => 'The kind of this something.' },
             'kind2' => { '$ref' => '#/definitions/ThisApi_Entities_Kind', 'description' => 'Secondary kind.' },

--- a/spec/support/shared_contexts/this_api.rb
+++ b/spec/support/shared_contexts/this_api.rb
@@ -31,6 +31,7 @@ shared_context 'this api' do
           expose :text, documentation: { type: 'string', desc: 'Content of something.' }
           expose :colors, documentation: { type: 'string', desc: 'Colors', is_array: true }
           expose :hidden_attr, documentation: { type: 'string', desc: 'Hidden', hidden: true }
+          expose :created_at, documentation: { type: Time, desc: 'Created at the time.' }
           expose :kind, using: Kind, documentation: { type: 'ThisApi::Kind', desc: 'The kind of this something.' }
           expose :kind2, using: Kind, documentation: { desc: 'Secondary kind.' }
           expose :kind3, using: ThisApi::Entities::Kind, documentation: { desc: 'Tertiary kind.' }


### PR DESCRIPTION
This PR fixes an issue where specifying a class like `Time` for the `type` option in `expose` documentation resulted in an error instead of generating the correct Swagger/OpenAPI specification.

This functionality was working correctly in v0.5.5 but regressed after PR #75, leading to the following error:

```
GrapeSwagger::Errors::UnregisteredParser:
  No parser registered for Time.
```

The `primitive_type?` method now uses `GrapeSwagger::DocMethods::DataType.call` to resolve the type name before checking if it's a primitive type.
This ensures that types like `Time` are correctly identified as strings with the `date-time` format, restoring the previous behavior.

@numbata Could you please take a look at this PR when you have a chance?