### PR TITLE
Fix: Recognize Grape::API::Boolean as a primitive type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 #### Fixes
 
 * Your contribution here.
-* [#82](https://github.com/ruby-grape/grape-swagger-entity/pull/82): Fix: recognize grape::api::boolean as a primitive type - [@numbata](https://github.com/numbata).
+* [#82](https://github.com/ruby-grape/grape-swagger-entity/pull/82): Fix: simplify primitive types recognition - [@numbata](https://github.com/numbata).
 
 ### 0.6.1 (2025/05/06)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 #### Fixes
 
 * Your contribution here.
+* [#82](https://github.com/ruby-grape/grape-swagger-entity/pull/82): Fix: recognize grape::api::boolean as a primitive type - [@numbata](https://github.com/numbata).
 
 ### 0.6.1 (2025/05/06)
 

--- a/lib/grape-swagger/entity/attribute_parser.rb
+++ b/lib/grape-swagger/entity/attribute_parser.rb
@@ -6,7 +6,7 @@ module GrapeSwagger
       attr_reader :endpoint
 
       # The list of that doesn't handled by `GrapeSwagger::DocMethods::DataType.primitive?` method
-      ADDITIONAL_PRIMITIVE_TYPES = %w[string array].freeze
+      ADDITIONAL_PRIMITIVE_TYPES = %w[boolean string array].freeze
 
       def initialize(endpoint)
         @endpoint = endpoint

--- a/lib/grape-swagger/entity/attribute_parser.rb
+++ b/lib/grape-swagger/entity/attribute_parser.rb
@@ -5,9 +5,6 @@ module GrapeSwagger
     class AttributeParser
       attr_reader :endpoint
 
-      # The list of that doesn't handled by `GrapeSwagger::DocMethods::DataType.primitive?` method
-      ADDITIONAL_PRIMITIVE_TYPES = %w[boolean string array].freeze
-
       def initialize(endpoint)
         @endpoint = endpoint
       end
@@ -61,8 +58,7 @@ module GrapeSwagger
 
       def primitive_type?(type)
         data_type = GrapeSwagger::DocMethods::DataType.call(type)
-        GrapeSwagger::DocMethods::DataType.primitive?(data_type) ||
-          ADDITIONAL_PRIMITIVE_TYPES.include?(data_type)
+        GrapeSwagger::DocMethods::DataType.request_primitive?(data_type)
       end
 
       def data_type_from(entity_options)

--- a/spec/grape-swagger/entity/attribute_parser_spec.rb
+++ b/spec/grape-swagger/entity/attribute_parser_spec.rb
@@ -263,7 +263,9 @@ describe GrapeSwagger::Entity::AttributeParser do
       end
 
       context 'when it is exposed as a Boolean class' do
-        let(:entity_options) { { documentation: { type: Grape::API::Boolean, example: example_value, default: example_value } } }
+        let(:entity_options) do
+          { documentation: { type: Grape::API::Boolean, example: example_value, default: example_value } }
+        end
 
         context 'when the example value is true' do
           let(:example_value) { true }

--- a/spec/grape-swagger/entity/attribute_parser_spec.rb
+++ b/spec/grape-swagger/entity/attribute_parser_spec.rb
@@ -262,6 +262,22 @@ describe GrapeSwagger::Entity::AttributeParser do
         it { is_expected.not_to include('$ref') }
       end
 
+      context 'when it is exposed as a Boolean class' do
+        let(:entity_options) { { documentation: { type: Grape::API::Boolean, example: example_value, default: example_value } } }
+
+        context 'when the example value is true' do
+          let(:example_value) { true }
+
+          it { is_expected.to include(type: 'boolean', example: example_value, default: example_value) }
+        end
+
+        context 'when the example value is false' do
+          let(:example_value) { false }
+
+          it { is_expected.to include(type: 'boolean', example: example_value, default: example_value) }
+        end
+      end
+
       context 'when it is exposed as a boolean' do
         let(:entity_options) { { documentation: { type: 'boolean', example: example_value, default: example_value } } }
 

--- a/spec/grape-swagger/entity/attribute_parser_spec.rb
+++ b/spec/grape-swagger/entity/attribute_parser_spec.rb
@@ -295,6 +295,22 @@ describe GrapeSwagger::Entity::AttributeParser do
           it { is_expected.to include(type: 'boolean', example: example_value, default: example_value) }
         end
       end
+
+      context 'when it is exposed as a hash' do
+        let(:entity_options) { { documentation: { type: Hash, example: example_value, default: example_value } } }
+
+        context 'when the example value is true' do
+          let(:example_value) { true }
+
+          it { is_expected.to include(type: 'object', example: example_value, default: example_value) }
+        end
+
+        context 'when the example value is false' do
+          let(:example_value) { false }
+
+          it { is_expected.to include(type: 'object', example: example_value, default: example_value) }
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
This pull request addresses an issue in the `GrapeSwagger::Entity::AttributeParser` where the `Grape::API::Boolean` and other type was not being recognized as a primitive type during Swagger schema generation.

These changes ensure that primitive types are correctly represented in the generated Swagger documentation.